### PR TITLE
Assert non-null return type

### DIFF
--- a/src/useLazyRef.ts
+++ b/src/useLazyRef.ts
@@ -1,10 +1,12 @@
-import {useRef, MutableRefObject} from 'react';
+import {useRef} from 'react';
 
 const useLazyRef = <T>(initialValFunc: () => T) => {
-    const ref: MutableRefObject<T | null> = useRef(null);
+    const ref = useRef<T>(null!);
+    
     if (ref.current === null) {
         ref.current = initialValFunc();
     }
+    
     return ref;
 };
 


### PR DESCRIPTION
Make sure the return type non-null.

```ts
const useTest = () => {
  const ref = useLazyRef(() => 123);

  const value = ref.current; // number
};
```
Before the `value` is a number or can be null. After the `value` is a number.